### PR TITLE
Bug Fix: Removed import in setup.py

### DIFF
--- a/apysigner.py
+++ b/apysigner.py
@@ -1,7 +1,3 @@
-
-__version__ = "3.0.0"
-
-
 import base64
 import datetime
 import decimal

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,9 @@ import os
 readme = os.path.join(os.path.dirname(__file__), 'README.rst')
 LONG_DESCRIPTION = open(readme, 'r').read()
 
-from apysigner import __version__
-
 params = dict(
     name='apysigner',
-    version=__version__,
+    version='3.0.0',
     url='https://github.com/madisona/apysigner',
     license='BSD',
     author='Aaron Madison',


### PR DESCRIPTION
Importing real code into setup.py causes that code to execute when
apysigner is being installed. Because dependencies are not installed yet
(six) this will cause errors.