### PR TITLE
Backwards Compatibility Issue

### DIFF
--- a/apysigner.py
+++ b/apysigner.py
@@ -88,6 +88,6 @@ class Signer(object):
         """
         Converts payload to a string. Complex objects are dumped to json
         """
-        if not isinstance(payload, six.string_types):
+        if not isinstance(payload, six.string_types) and payload:
             payload = json.dumps(payload, cls=DefaultJSONEncoder, sort_keys=True)
-        return str(payload)
+        return str(payload or "")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ LONG_DESCRIPTION = open(readme, 'r').read()
 
 params = dict(
     name='apysigner',
-    version='3.0.1',
+    version='3.0.2',
     url='https://github.com/madisona/apysigner',
     license='BSD',
     author='Aaron Madison',

--- a/test_apysigner.py
+++ b/test_apysigner.py
@@ -31,7 +31,7 @@ class SignatureMakerTests(TestCase):
 
     def test_signs_request_with_no_payload(self):
         signature = self.signer.create_signature('http://www.example.com/accounts/?one=1&two=2&two=dos&two=two')
-        expected_signature = 'LmE4gGmqmPX8L2YuEWH1YgE5G9Kc3JzK8NzjznFVjV0='
+        expected_signature = 'bm9_IDIQtEElubM5r__M0kDMUfdQ__0ZSI-2Bi6DcRo='
         self.assertEqual(expected_signature, signature)
 
     def test_signs_request_when_private_key_is_unicode(self):
@@ -41,7 +41,7 @@ class SignatureMakerTests(TestCase):
         signer = Signer(six.text_type(self.private_key))
         signature = signer.create_signature('http://www.example.com/accounts/user/add/')
 
-        expected_signature = '5KUwEjFvjc2T_IxJX_uL00nRC1HJrk_LOs1sXu1DrHY='
+        expected_signature = '2ZzgF8AGioIfYzPqedI0FfJKEDG2asRA1LR70q4IOYs='
         self.assertEqual(expected_signature, signature)
 
     def test_requires_private_key(self):
@@ -49,6 +49,17 @@ class SignatureMakerTests(TestCase):
             Signer(None)
 
         self.assertEqual(str(context.exception), 'Private key is required.')
+
+    def test_signature_is_same_with_different_blank_payloads(self):
+        base_url = 'http://www.example.com/'
+        signatures = set([
+            get_signature(self.private_key, base_url, None),
+            get_signature(self.private_key, base_url, ""),
+            get_signature(self.private_key, base_url, {}),
+        ])
+        self.assertEqual(1, len(signatures))
+        # all should be same as the empty string version
+        self.assertEqual(get_signature(self.private_key, base_url, ""), signatures.pop())
 
     def test_get_signature_creates_signature_with_payload_data(self):
         base_url = 'http://www.example.com/accounts/user/add/'
@@ -60,13 +71,67 @@ class SignatureMakerTests(TestCase):
 
     def test_get_signature_with_complex_non_unicode_payload(self):
         base_url = 'http://www.example.com/accounts/user/add/'
-        data = {'coverages': [{'construction_type': u'', 'premium': None, 'fire_class': None, 'optional_coverages': [{'construction_type': u'', 'irpms': [], 'fire_class': None, 'deductible_code': u'500', 'coverage_amount': '100000', 'territory': None, 'rate_code': u'033', 'year_built': None}], 'rate_code': u'005', 'property_id': '6b86b273ff3', 'packages': [], 'year_built': None, 'coverage_amount': '100000', 'irpms': [], 'deductible_code': u'500', 'territory': None}, {'construction_type': u'', 'premium': None, 'fire_class': None, 'optional_coverages': [], 'rate_code': u'015', 'property_id': 'd4735e3a265', 'packages': [{'rate_code': u'017', 'irpms': [], 'construction_type': u'', 'deductible_code': u'500', 'fire_class': None, 'rateable_amount': 10000, 'territory': None, 'property_id': '6b86b273ff3'}], 'year_built': None, 'coverage_amount': '100000', 'irpms': [], 'deductible_code': u'500', 'territory': None}, {'construction_type': u'', 'premium': None, 'fire_class': None, 'optional_coverages': [{'construction_type': u'', 'irpms': [], 'fire_class': None, 'deductible_code': u'500', 'coverage_amount': '100000', 'territory': None, 'rate_code': u'033', 'year_built': None}], 'rate_code': u'002', 'property_id': '4e07408562b', 'packages': [], 'year_built': None, 'coverage_amount': '100000', 'irpms': [u'RCC'], 'deductible_code': u'500', 'territory': None}], 'producer': u'matt.morrison', 'policy_type': u'FM', 'policy': {'effective_date': None, 'path': 'APPS9690', 'apps_key': u'FM', 'discount_a': u'1'}, 'company': 9690, 'agency': None, 'policy_id': 1}
+        data = {'coverages': [{
+            'construction_type': u'', 'premium': None, 'fire_class': None, 'optional_coverages': [{
+                'construction_type': u'', 'irpms': [], 'fire_class': None, 'deductible_code': u'500',
+                'coverage_amount': '100000', 'territory': None, 'rate_code': u'033', 'year_built': None
+                }],
+            'rate_code': u'005', 'property_id': '6b86b273ff3', 'packages': [], 'year_built': None,
+            'coverage_amount': '100000', 'irpms': [], 'deductible_code': u'500', 'territory': None
+            }, {
+                'construction_type': u'', 'premium': None, 'fire_class': None, 'optional_coverages': [],
+                'rate_code': u'015', 'property_id': 'd4735e3a265', 'packages': [{
+                    'rate_code': u'017', 'irpms': [], 'construction_type': u'', 'deductible_code': u'500',
+                    'fire_class': None, 'rateable_amount': 10000, 'territory': None, 'property_id': '6b86b273ff3'
+                }],
+                'year_built': None, 'coverage_amount': '100000', 'irpms': [], 'deductible_code': u'500',
+                'territory': None
+            }, {
+                'construction_type': u'', 'premium': None, 'fire_class': None, 'optional_coverages': [{
+                    'construction_type': u'', 'irpms': [], 'fire_class': None, 'deductible_code': u'500',
+                    'coverage_amount': '100000', 'territory': None, 'rate_code': u'033', 'year_built': None
+                }],
+                'rate_code': u'002', 'property_id': '4e07408562b', 'packages': [], 'year_built': None,
+                'coverage_amount': '100000', 'irpms': [u'RCC'], 'deductible_code': u'500', 'territory': None
+            }],
+            'producer': u'matt.morrison', 'policy_type': u'FM', 'policy': {
+                'effective_date': None, 'path': 'APPS9690', 'apps_key': u'FM', 'discount_a': u'1'
+            }, 'company': 9690, 'agency': None, 'policy_id': 1
+        }
         signature = get_signature(self.private_key, base_url, data)
         expected_signature = '0WhQvC9ZLTIBsLn_N6cfC25qVmwgfsfFMJYlFEWFj4k='
         self.assertEqual(expected_signature, signature)
 
     def test_convert_function_will_also_sort_dict_based_on_key(self):
-        d = {u'coverages': [{u'construction_type': u'', u'premium': None, u'coverage_amount': u'100000', u'territory': None, u'irpms': [], u'fire_class': None, u'deductible_code': u'500', u'optional_coverages': [{u'construction_type': u'', u'year_built': None, u'coverage_amount': u'100000', u'irpms': [], u'fire_class': None, u'deductible_code': u'500', u'territory': None, u'rate_code': u'033'}], u'packages': [], u'year_built': None, u'rate_code': u'005', u'property_id': u'6b86b273ff3'}, {u'construction_type': u'', u'premium': None, u'coverage_amount': u'100000', u'territory': None, u'irpms': [], u'fire_class': None, u'deductible_code': u'500', u'optional_coverages': [], u'packages': [{u'fire_class': None, u'rate_code': u'017', u'irpms': [], u'construction_type': u'', u'deductible_code': u'500', u'rateable_amount': 10000, u'territory': None, u'property_id': u'6b86b273ff3'}], u'year_built': None, u'rate_code': u'015', u'property_id': u'd4735e3a265'}, {u'construction_type': u'', u'premium': None, u'coverage_amount': u'100000', u'territory': None, u'irpms': [u'RCC'], u'fire_class': None, u'deductible_code': u'500', u'optional_coverages': [{u'construction_type': u'', u'year_built': None, u'coverage_amount': u'100000', u'irpms': [], u'fire_class': None, u'deductible_code': u'500', u'territory': None, u'rate_code': u'033'}], u'packages': [], u'year_built': None, u'rate_code': u'002', u'property_id': u'4e07408562b'}], u'producer': u'matt.morrison', u'company': 9690, u'agency': None, u'policy_type': u'FM', u'policy': {u'effective_date': None, u'path': u'APPS9690', u'apps_key': u'FM', u'discount_a': u'1'}, u'policy_id': 1}
+        d = {u'coverages': [{
+            u'construction_type': u'', u'premium': None, u'coverage_amount': u'100000', u'territory': None,
+            u'irpms': [], u'fire_class': None, u'deductible_code': u'500', u'optional_coverages': [{
+                u'construction_type': u'', u'year_built': None, u'coverage_amount': u'100000', u'irpms': [],
+                u'fire_class': None, u'deductible_code': u'500', u'territory': None, u'rate_code': u'033'
+            }],
+            u'packages': [], u'year_built': None, u'rate_code': u'005', u'property_id': u'6b86b273ff3'
+            }, {
+                u'construction_type': u'', u'premium': None, u'coverage_amount': u'100000', u'territory': None,
+                u'irpms': [], u'fire_class': None, u'deductible_code': u'500', u'optional_coverages': [],
+                u'packages': [{
+                    u'fire_class': None, u'rate_code': u'017', u'irpms': [], u'construction_type': u'',
+                    u'deductible_code': u'500', u'rateable_amount': 10000, u'territory': None,
+                    u'property_id': u'6b86b273ff3'
+                }],
+                u'year_built': None, u'rate_code': u'015', u'property_id': u'd4735e3a265'
+            }, {
+                u'construction_type': u'', u'premium': None, u'coverage_amount': u'100000', u'territory': None,
+                u'irpms': [u'RCC'], u'fire_class': None, u'deductible_code': u'500', u'optional_coverages': [{
+                    u'construction_type': u'', u'year_built': None, u'coverage_amount': u'100000', u'irpms': [],
+                    u'fire_class': None, u'deductible_code': u'500', u'territory': None, u'rate_code': u'033'
+                }],
+                u'packages': [], u'year_built': None, u'rate_code': u'002', u'property_id': u'4e07408562b'
+                }],
+            u'producer': u'matt.morrison', u'company': 9690, u'agency': None, u'policy_type': u'FM', u'policy': {
+                u'effective_date': None, u'path': u'APPS9690', u'apps_key': u'FM', u'discount_a': u'1'
+            },
+            u'policy_id': 1
+        }
         unicode_payload = self.signer._convert(d)
         d_sig = self.signer.create_signature("http://example.com", d)
         u_sig = self.signer.create_signature("http://example.com", unicode_payload)
@@ -74,7 +139,7 @@ class SignatureMakerTests(TestCase):
 
     def test_get_signature_signs_request_with_no_payload(self):
         signature = get_signature(self.private_key, 'http://www.example.com/accounts/?one=1&two=2&two=dos&two=two')
-        expected_signature = 'LmE4gGmqmPX8L2YuEWH1YgE5G9Kc3JzK8NzjznFVjV0='
+        expected_signature = 'bm9_IDIQtEElubM5r__M0kDMUfdQ__0ZSI-2Bi6DcRo='
         self.assertEqual(expected_signature, signature)
 
     def test_convert_returns_string_when_already_string(self):


### PR DESCRIPTION
Previously, when creating a signature with a payload of `None`, `""` or
`{}` would all result in the same signature. After the changes in 3.0
this is no longer true. Each of those 3 scenarios result in a different
signature. This is a problem for the other implementations of the
request signer (Perl, C#). With this change signatures with no payload
(whether it is `""`, `{}` or `None`) will all be the same (which works
like the `""` version in the broken 3.0 version - which is what happened
before 3.0).
